### PR TITLE
chore(release): 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "switch-policies",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "switch-policies",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@koa/router": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowbuild/switch-policies",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "System to register switch policies and inspect processes",
   "main": "index.js",
   "author": "FDTE-DSD",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.4.0](https://github.com/flow-build/workflow-switches/releases/tag/v1.4.0)